### PR TITLE
feat: declare aws.modernisation-platform configuration alias

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 6.0"
-      source  = "hashicorp/aws"
+      version               = "~> 6.0"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.modernisation-platform]
     }
   }
   required_version = "~> 1.0"


### PR DESCRIPTION
## What

Add `configuration_aliases = [aws.modernisation-platform]` to the `aws` provider entry in `required_providers`.

## Why

The module internally uses `provider = aws.modernisation-platform` for PagerDuty integration resources, but this alias was never formally declared. Terraform raised a warning for any caller passing `aws.modernisation-platform` in their `providers` block:

```
Warning: Reference to undefined provider
There is no explicit declaration for local provider name
"aws.modernisation-platform" in module.waf
```

Declaring `configuration_aliases` is the correct Terraform pattern to resolve this — it makes the accepted provider aliases explicit without making the module MP-specific. Callers that do not use PagerDuty integration can simply map the alias to their default provider:

```hcl
providers = {
  aws                        = aws
  aws.modernisation-platform = aws
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)